### PR TITLE
Use gateway instead of 0.0.0.0 to allow docker in docker

### DIFF
--- a/test_integration.py
+++ b/test_integration.py
@@ -12,13 +12,14 @@ class ToxDockerIntegrationTest(unittest.TestCase):
 
     def test_it_sets_automatic_env_vars(self):
         # the nginx image we use exposes port 80
+        self.assertIn("NGINX_HOST", os.environ)
         self.assertIn("NGINX_80_TCP", os.environ)
         # the telegraf image we use exposes UDP port 8092
         self.assertIn("TELEGRAF_8092_UDP", os.environ)
 
     def test_it_exposes_the_port(self):
         # the nginx image we use exposes port 80
-        url = "http://127.0.0.1:{port}/".format(port=os.environ["NGINX_80_TCP"])
+        url = "http://{host}:{port}/".format(host=os.environ["NGINX_HOST"], port=os.environ["NGINX_80_TCP"])
         response = urllib2.urlopen(url)
         self.assertEqual(200, response.getcode())
         self.assertIn("Thank you for using nginx.", response.read())

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,6 +1,10 @@
 import os
 import unittest
-import urllib2
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 
 class ToxDockerIntegrationTest(unittest.TestCase):
@@ -20,6 +24,6 @@ class ToxDockerIntegrationTest(unittest.TestCase):
     def test_it_exposes_the_port(self):
         # the nginx image we use exposes port 80
         url = "http://{host}:{port}/".format(host=os.environ["NGINX_HOST"], port=os.environ["NGINX_80_TCP"])
-        response = urllib2.urlopen(url)
+        response = urlopen(url)
         self.assertEqual(200, response.getcode())
-        self.assertIn("Thank you for using nginx.", response.read())
+        self.assertIn("Thank you for using nginx.", str(response.read()))

--- a/test_registry.py
+++ b/test_registry.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+import urllib2
+
+
+class ToxDockerRegistryTest(unittest.TestCase):
+    def test_it_sets_specific_env_vars(self):
+        self.assertEqual("env-var-value", os.environ["ENV_VAR"])
+
+    def test_it_sets_automatic_env_vars(self):
+        # the nginx image we use exposes port 80
+        self.assertIn("DOCKER_IO_LIBRARY_NGINX_HOST", os.environ)
+        self.assertIn("DOCKER_IO_LIBRARY_NGINX_80_TCP", os.environ)
+
+    def test_it_exposes_the_port(self):
+        # the nginx image we use exposes port 80
+        url = "http://{host}:{port}/".format(host=os.environ["DOCKER_IO_LIBRARY_NGINX_HOST"], port=os.environ["DOCKER_IO_LIBRARY_NGINX_80_TCP"])
+        response = urllib2.urlopen(url)
+        self.assertEqual(200, response.getcode())
+        self.assertIn("Thank you for using nginx.", response.read())

--- a/test_registry.py
+++ b/test_registry.py
@@ -1,6 +1,10 @@
 import os
 import unittest
-import urllib2
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 
 class ToxDockerRegistryTest(unittest.TestCase):
@@ -15,6 +19,6 @@ class ToxDockerRegistryTest(unittest.TestCase):
     def test_it_exposes_the_port(self):
         # the nginx image we use exposes port 80
         url = "http://{host}:{port}/".format(host=os.environ["DOCKER_IO_LIBRARY_NGINX_HOST"], port=os.environ["DOCKER_IO_LIBRARY_NGINX_80_TCP"])
-        response = urllib2.urlopen(url)
+        response = urlopen(url)
         self.assertEqual(200, response.getcode())
-        self.assertIn("Thank you for using nginx.", response.read())
+        self.assertIn("Thank you for using nginx.", str(response.read()))

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py27
+envlist = integration,registry
 
-[testenv]
+[testenv:integration]
 docker =
     nginx:1.13-alpine
     telegraf:1.8-alpine
@@ -10,3 +10,11 @@ dockerenv =
 ; docker_use_gateway = True
 deps = pytest
 commands = py.test [] test_integration.py
+
+[testenv:registry]
+docker = docker.io/library/nginx:1.13-alpine
+dockerenv =
+    ENV_VAR=env-var-value
+; docker_use_gateway = True
+deps = pytest
+commands = py.test [] test_registry.py

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ docker =
     telegraf:1.8-alpine
 dockerenv =
     ENV_VAR=env-var-value
-; docker_use_gateway = True
 deps = pytest
 commands = py.test [] test_integration.py
 
@@ -15,6 +14,5 @@ commands = py.test [] test_integration.py
 docker = docker.io/library/nginx:1.13-alpine
 dockerenv =
     ENV_VAR=env-var-value
-; docker_use_gateway = True
 deps = pytest
 commands = py.test [] test_registry.py

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,6 @@ docker =
     telegraf:1.8-alpine
 dockerenv =
     ENV_VAR=env-var-value
+; docker_use_gateway = True
 deps = pytest
 commands = py.test [] test_integration.py

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -70,9 +70,7 @@ def tox_runtest_pre(venv):
         conf._docker_containers.append(container)
 
         container.reload()
-        gateway_ip = "0.0.0.0"
-        if conf.docker_use_gateway and container.attrs["NetworkSettings"]["Gateway"]:
-            gateway_ip = container.attrs["NetworkSettings"]["Gateway"]
+        gateway_ip = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
         for containerport, hostports in container.attrs["NetworkSettings"]["Ports"].items():
             hostport = None
             for spec in hostports:
@@ -146,10 +144,4 @@ def tox_addoption(parser):
         type="line-list",
         help="List of ENVVAR=VALUE pairs that will be passed to all containers",
         default=[],
-    )
-    parser.add_testenv_attribute(
-        name="docker_use_gateway",
-        type="bool",
-        help="Use gateway ip instead of 0.0.0.0 to connect on container",
-        default=False,
     )

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -8,6 +8,12 @@ import docker as docker_module
 
             
 def escape_env_var(varname):
+    """Uppercase and sanitize the env var name by replacing
+        all invalid characters by an underscore.
+    The result will match the following regex: [a-zA-Z_][a-zA-Z0-9_]*
+    Example:
+        my.private.registry/cat/image will become MY_PRIVATE_REGISTRY_CAT_IMAGE
+    """
     varname = list(varname.upper())
     if not varname[0].isalpha():
         varname[0] = '_'


### PR DESCRIPTION
I want to use tox-docker inside docker (docker in docker). But using `0.0.0.0` or `localhost` doestn't work in this case.
That why I made this PR to add an option `docker_use_gateway` which use docker gateway ip to test connection with the container. I also add a new environment var `XXX_HOST` to save the gateway ip.

Finally, I replace `name.upper()` by a call to `escape_env_var()` because when you use a private registry, the name with the URL is not correctly escaped. Example: `my.registry.com/myimage` became `MY.REGISTRY.COM/MYIMAGE` instead of `MY_REGISTRY_COM_MYIMAGE`.

To test the failure case:
`docker run --rm -ti -v $(pwd):/src -w /src -v /var/run/docker.sock:/var/run/docker.sock -v /etc/passwd:/etc/passwd -v /etc/group:/etc/group docker sh -c 'apk add python py-pip ; pip install . ; tox'`
In `tox.ini`, if you set `docker_use_gateway` to `True`, the previous command will success.  