### PR TITLE
assume that service with UDP port always up

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,6 @@ container exposes will be made available to your test suite via environment
 variables of the form `<image-basename>_<exposed-port>_<proto>`. For
 instance, for the postgresql container, there will be an environment
 variable `POSTGRES_5432_TCP` whose value is the ephemeral port number that
-docker has bound the container's port 5432 to.
+docker has bound the container's port 5432 to.  
+NB! Since it's not possible to check whether UDP port is open
+it's just mapping to environment variable without any checks that service up and running.

--- a/test_integration.py
+++ b/test_integration.py
@@ -13,6 +13,8 @@ class ToxDockerIntegrationTest(unittest.TestCase):
     def test_it_sets_automatic_env_vars(self):
         # the nginx image we use exposes port 80
         self.assertIn("NGINX_80_TCP", os.environ)
+        # the telegraf image we use exposes UDP port 8092
+        self.assertIn("TELEGRAF_8092_UDP", os.environ)
 
     def test_it_exposes_the_port(self):
         # the nginx image we use exposes port 80

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py27
 
 [testenv]
-docker = nginx:1.13-alpine
+docker =
+    nginx:1.13-alpine
+    telegraf:1.8-alpine
 dockerenv =
     ENV_VAR=env-var-value
 deps = pytest

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -70,6 +70,10 @@ def tox_runtest_pre(venv):
             )
             venv.envconfig.setenv[envvar] = hostport
 
+            _, proto = containerport.split("/")
+            if proto == "udp":
+                continue
+
             # mostly-busy-loop until we can connect to that port; that
             # will be our signal that the container is ready (meh)
             start = time.time()


### PR DESCRIPTION
I want to test snmpd service with tox docker, but I need UDP port. There's no way to check if UDP port is open/listening, without some unix utils, so I added workaround. Thoughts?

```
Traceback (most recent call last):
...
  File "/lib/python3.6/site-packages/tox_docker.py", line 90, in tox_runtest_pre
    "Never got answer on port {} from {}".format(containerport, name)
Exception: Never got answer on port 161/udp from ...
```