### PR TITLE
Added build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 _version.py
 version.txt
 *.pyc
+.tox
+.eggs
+tox_docker.egg-info
+build/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,7 @@ env:
     - TOX_VERSION="tox-3.x"
 install:
     - pip install --constraint "$TOX_VERSION" .
-script: "tox"
+script:
+    - tox
+    # assure that we fail a build if it contains leftovers
+    - git diff --exit-code


### PR DESCRIPTION
Assures that CI will not pass if there are leftovers after running
tests, preventing regression on this bug.