### PR TITLE
update the travis ci build structrue for supporting py27 and py36 tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 _version.py
 version.txt
 *.pyc
+.tox
+.eggs
+tox_docker.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ language: python
 services:
     - docker
 python:
-    - "2.7"
-    - "3.5"
-    - "3.6"
+  - "2.7"
+  - "3.5"
+  - "3.6"
 env:
-    - TOX_VERSION="tox-2.x"
-    - TOX_VERSION="tox-3.x"
+  matrix:
+#    - SCENARIO_NAME=py27-test
+    - SCENARIO_NAME=test
 install:
-    - pip install --constraint "$TOX_VERSION" .
-script: "tox"
+  - pip install tox-travis
+  - pip install -e ${TRAVIS_BUILD_DIR}
+script:
+  - tox -e ${SCENARIO_NAME}

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,8 +1,11 @@
 import os
 import unittest
-import urllib2
 
-
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+    
 class ToxDockerIntegrationTest(unittest.TestCase):
     # TODO: These tests depend too heavily on what's in tox.ini,
     # but they're better than nothing
@@ -19,6 +22,6 @@ class ToxDockerIntegrationTest(unittest.TestCase):
     def test_it_exposes_the_port(self):
         # the nginx image we use exposes port 80
         url = "http://127.0.0.1:{port}/".format(port=os.environ["NGINX_80_TCP"])
-        response = urllib2.urlopen(url)
+        response = urlopen(url)
         self.assertEqual(200, response.getcode())
-        self.assertIn("Thank you for using nginx.", response.read())
+        self.assertIn("Thank you for using nginx.", str(response.read()))

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py27
+envlist = {py27,py36}-{test}
 
 [testenv]
 docker =
-    nginx:1.13-alpine
-    telegraf:1.8-alpine
+    nginx:1.15.8-alpine
+    telegraf:1.9-alpine
 dockerenv =
     ENV_VAR=env-var-value
-deps = pytest
+deps =
+  pytest
 commands = py.test [] test_integration.py


### PR DESCRIPTION
fixed #13, call the tox "test" env with the system python version.