### PR TITLE
[WIP] Add 'skip_port_validation' flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,3 +83,14 @@ must *exactly* match the image name used in your testenv's ``docker`` setting.
 tox-docker will print a message for each container that it is waiting on a
 health check from, whether via the container's built-in ``HEALTHCHECK`` or a
 custom health check.
+
+Port Scanning
+-------------
+
+Since version 1.0, tox-docker has scanned published ports of created containers
+to determine when the image is active. However, not all published ports may be
+active at a given time which can result in errors. As of version 1.5, tox-docker
+allows you to disable this behavior if necessary, in a new section like::
+
+    [docker:mysql:5.6]
+    skip_port_validation = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ version = release = vcversioner.find_version(root=ROOT_DIR).version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'reno.sphinxext',
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,1 +1,6 @@
 .. include:: ../../README.rst
+
+Release notes
+-------------
+
+.. release-notes::

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,11 @@
+---
+earliest_version: v1.4.0
+release_tag_re: 'v\d\.\d\.\d(rc\d+)?'
+sections:
+  # The prelude section is implicitly included.
+  - [features, New Features]
+  - [issues, Known Issues]
+  - [upgrade, Upgrade Notes]
+  - [deprecations, Deprecation Notes]
+  - [fixes, Bug Fixes]
+  - [other, Other Notes]

--- a/releasenotes/notes/add-skip_port_validation-flag-40921e653b8feb05.yaml
+++ b/releasenotes/notes/add-skip_port_validation-flag-40921e653b8feb05.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    A new ``skip_port_validation`` flag is added. This can be used to disable
+    port scanning for created instances and is useful for images that provide
+    optional port. It can be configured for each image in a ``[docker:IMAGE]``
+    section. For example::
+
+        [docker:mysql:8.0]
+        skip_port_validation = True

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     sphinx
     sphinx_rtd_theme
     vcversioner
+    reno
 commands = sphinx-build -W -b html docs/source docs/build/html
 commands_pre =
 commands_post =

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -100,6 +100,7 @@ def tox_configure(config):
             "healthcheck_timeout": gettime(reader, "healthcheck_timeout"),
             "healthcheck_retries": getint(reader, "healthcheck_retries"),
             "healthcheck_start_period": gettime(reader, "healthcheck_start_period"),
+            "skip_port_validation": reader.getbool("skip_port_validation", default=False),
         }
 
     config._docker_image_configs = image_configs
@@ -223,6 +224,10 @@ def tox_runtest_pre(venv):
 
             _, proto = containerport.split("/")
             if proto == "udp":
+                continue
+
+            # skip port validation if user requests it
+            if image_configs[image]["skip_port_validation"]:
                 continue
 
             # mostly-busy-loop until we can connect to that port; that


### PR DESCRIPTION
This allows us to skip port validation for images that publish multiple
ports, not all of which may be active at any given time. We also
introduce reno, which is a release note manager that we can use to
produce a helpful changelog for users.

This is marked WIP since I haven't tested it and it needs unit tests.