### PR TITLE
add manual publications of ports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,12 +40,23 @@ your test suite as it runs, as ordinary environment variables::
 Host and Port Mapping
 ---------------------
 
-tox-docker runs docker with the "publish all ports" option. Any port the
-container exposes will be made available to your test suite via environment
-variables of the form ``<image-basename>_<exposed-port>_<protocol>_PORT``.
-For instance, for the PostgreSQL container, there will be an environment
-variable ``POSTGRES_5432_TCP_PORT`` whose value is the ephemeral port number
-that docker has bound the container's port 5432 to.
+By default, tox-docker runs the container with the "publish all ports" option.
+You may also specify port publishing in ``tox.ini``, in a new section like::
+
+    [docker:redis:5.0-alpine]
+    ports = 5432:5432/tcp
+
+The image name -- everything after the ``docker:`` in the section header --
+must *exactly* match the image name used in your testenv's ``docker`` setting.
+Published ports are separated by a newline and are in the format
+``<HOST>:<CONTAINER>/<PROTOCOL>``.
+
+Any port the container exposes will be made available to your test suite via
+environment variables of the form
+``<image-basename>_<exposed-port>_<protocol>_PORT``.  For instance, for the
+PostgreSQL container, there will be an environment variable
+``POSTGRES_5432_TCP_PORT`` whose value is the ephemeral port number that docker
+has bound the container's port 5432 to.
 
 Likewise, exposed UDP ports will have environment variables like
 ``TELEGRAF_8092_UDP_PORT`` Since it's not possible to check whether UDP port

--- a/test_ports.py
+++ b/test_ports.py
@@ -1,0 +1,18 @@
+import unittest
+
+import docker
+
+
+class ToxDockerPortTest(unittest.TestCase):
+
+    def test_it_exposes_only_specified_port(self):
+        client = docker.from_env(version="auto")
+        mysql_container = None
+        for container in client.containers.list()
+          if "mysql" in containers.attrs["Config"]["Image"]:
+              mysql_container = container
+              break
+
+        self.assertIsNotNone(mysql_container, "could not find mysql container")
+        self.assertIsNotNone(mysql_container.attrs["NetworkSettings"]["Ports"].get("3306/tcp"))
+        self.assertIsNone(mysql_container.attrs["NetworkSettings"]["Ports"].get("33060/tcp"))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = integration,registry,healthcheck-builtin,healthcheck-custom
+envlist = integration,registry,healthcheck-builtin,healthcheck-custom,ports
 
 [testenv]
 # commands_pre/_post only work in tox 3.4+, but at least in some
@@ -46,3 +46,16 @@ healthcheck_interval = 1
 healthcheck_timeout = 1
 healthcheck_retries = 30
 healthcheck_start_period = 0.5
+
+[testenv:ports]
+docker = mysql:5.7
+deps = pytest
+commands = py.test [] test_ports.py
+
+[docker:mysql:5.7]
+healthcheck_cmd = mysql -uroot -D information_schema -e "SELECT * FROM plugins LIMIT 0;"
+healthcheck_interval = 30
+healthcheck_timeout = 10
+healthcheck_retries = 3
+healthcheck_start_period = 30
+ports = 3306:3306/tcp


### PR DESCRIPTION
I really needed to solve #35. Thus this PR applies the feedback from #36 to add a configurable ports section to the image config. When it is not provided or the empty string is provided, it falls back to publishing all ports, so the change entirely backwards compatible. Ports are expected to be space separated and are formatted `$HOSTPORT:$CONTAINERPORT/$PROTOCOL`.

A working example using MySQL 5.7:
```
[docker:mysql:5.7]
healthcheck_cmd = mysql -uroot -D information_schema -e "SELECT * FROM plugins LIMIT 0;"
healthcheck_interval = 25
healthcheck_timeout = 10
healthcheck_retries = 3
healthcheck_start_period = 25
ports = 3306:3306/tcp
```