### PR TITLE
Fix issue 52

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,3 +83,9 @@ must *exactly* match the image name used in your testenv's ``docker`` setting.
 tox-docker will print a message for each container that it is waiting on a
 health check from, whether via the container's built-in ``HEALTHCHECK`` or a
 custom health check.
+
+If you are running in a Docker-In-Docker environment, you can override the
+address used for port checking using the environment variables
+``TOX_DOCKER_GATEWAY_HOST`` or ``TOX_DOCKER_GATEWAY_IP``.  These variables
+may not be specified together as the case is ambiguous.  Use whichever is
+more convenient for your environment.

--- a/test_integration.py
+++ b/test_integration.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 import os
 import sys
 import unittest
+from unittest.mock import patch
 
 try:
     from urllib.request import urlopen
@@ -82,7 +83,7 @@ class GatewayIpTest(unittest.TestCase):
         with sys_platform_as("linux2"):
             self.assertEqual(_get_gateway_ip(container), "1.2.3.4")
 
-            with unittest.mock.patch.dict('os.environ', {'TOX_DOCKER_GATEWAY_IP': '192.168.1.1'}):
+            with patch.dict('os.environ', {'TOX_DOCKER_GATEWAY_IP': '192.168.1.1'}):
                 self.assertEqual(_get_gateway_ip(container), "192.168.1.1")
 
             self.assertEqual(_get_gateway_ip(container), "1.2.3.4")

--- a/test_integration.py
+++ b/test_integration.py
@@ -71,3 +71,18 @@ class MacOSTest(unittest.TestCase):
 
         with sys_platform_as("darwin"):
             self.assertEqual(_get_gateway_ip(container), "0.0.0.0")
+
+
+class GatewayIpTest(unittest.TestCase):
+    def test_gateway_ip_env_override(self):
+        class NotARealContainer(object):
+            attrs = {"NetworkSettings": {"Gateway": "1.2.3.4", }}
+        container = NotARealContainer()
+
+        with sys_platform_as("linux2"):
+            self.assertEqual(_get_gateway_ip(container), "1.2.3.4")
+
+            with unittest.mock.patch.dict('os.environ', {'TOX_DOCKER_GATEWAY_IP': '192.168.1.1'}):
+                self.assertEqual(_get_gateway_ip(container), "192.168.1.1")
+
+            self.assertEqual(_get_gateway_ip(container), "1.2.3.4")

--- a/test_integration.py
+++ b/test_integration.py
@@ -107,5 +107,5 @@ class GatewayIpTest(unittest.TestCase):
         container = NotARealContainer()
 
         with patch.dict('os.environ', {'TOX_DOCKER_GATEWAY_HOST': 'localhost', 'TOX_DOCKER_GATEWAY_IP': '192.168.1.1'}):
-            with self.assertRaises(RuntimeException):
+            with self.assertRaises(RuntimeError):
                 _get_gateway_ip(container)

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -1,3 +1,4 @@
+import os
 import socket
 import sys
 import time
@@ -47,13 +48,16 @@ def _newaction(venv, message):
 
 
 def _get_gateway_ip(container):
-    if sys.platform == "darwin":
-        # per https://docs.docker.com/v17.12/docker-for-mac/networking/#use-cases-and-workarounds,
-        # there is no bridge network available in Docker for Mac, and exposed ports are made
-        # available on localhost (but 0.0.0.0 works just as well)
-        return "0.0.0.0"
-    else:
-        return container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
+    addr = os.getenv('TOX_DOCKER_GATEWAY_IP')
+    if not addr:
+        if sys.platform == "darwin":
+            # per https://docs.docker.com/v17.12/docker-for-mac/networking/#use-cases-and-workarounds,
+            # there is no bridge network available in Docker for Mac, and exposed ports are made
+            # available on localhost (but 0.0.0.0 works just as well)
+            addr = "0.0.0.0"
+        else:
+            addr = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
+    return addr
 
 
 @hookimpl

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -48,16 +48,21 @@ def _newaction(venv, message):
 
 
 def _get_gateway_ip(container):
-    addr = os.getenv('TOX_DOCKER_GATEWAY_IP')
-    if not addr:
+    host = os.getenv('TOX_DOCKER_GATEWAY_HOST')
+    ip = os.getenv('TOX_DOCKER_GATEWAY_IP')
+    if host and ip:
+        raise RuntimeError('Environment variables "TOX_DOCKER_GATEWAY_HOST" and "TOX_DOCKER_GATEWAY_IP" must not be specified together.')
+    elif host:
+        ip = socket.gethostbyname(host)
+    if not ip:
         if sys.platform == "darwin":
             # per https://docs.docker.com/v17.12/docker-for-mac/networking/#use-cases-and-workarounds,
             # there is no bridge network available in Docker for Mac, and exposed ports are made
             # available on localhost (but 0.0.0.0 works just as well)
-            addr = "0.0.0.0"
+            ip = "0.0.0.0"
         else:
-            addr = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
-    return addr
+            ip = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
+    return ip
 
 
 @hookimpl


### PR DESCRIPTION
Added ability to override gateway ip via environment variables

Fixes https://github.com/tox-dev/tox-docker/issues/52