### PR TITLE
fail the tox run if a container's healthcheck fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,35 +22,14 @@ jobs:
       versionSpec: '$(python.version)'
       architecture: 'x64'
 
-  - script: |
-      pip install --constraint tox-2.x --constraint docker-3.x .
-      pip show tox tox-docker docker
-      tox
-      # check if there are any changes to tracked files, which should fail the build
-      git diff-index --quiet HEAD --
+  - script: ./ci.sh tox-2.x docker-3.x
     displayName: 'Tox 2.x, Docker 3.x'
 
-
-  - script: |
-      pip install --constraint tox-2.x --constraint docker-4.x .
-      pip show tox tox-docker docker
-      tox
-      # check if there are any changes to tracked files, which should fail the build
-      git diff-index --quiet HEAD --
+  - script: ./ci.sh tox-2.x docker-4.x
     displayName: 'Tox 2.x, Docker 4.x'
 
-  - script: |
-      pip install --constraint tox-3.x --constraint docker-3.x .
-      pip show tox tox-docker docker
-      tox
-      # check if there are any changes to tracked files, which should fail the build
-      git diff-index --quiet HEAD --
+  - script: ./ci.sh tox-3.x docker-3.x
     displayName: 'Tox 3.x, Docker 3.x'
 
-  - script: |
-      pip install --constraint tox-3.x --constraint docker-4.x .
-      pip show tox tox-docker docker
-      tox
-      # check if there are any changes to tracked files, which should fail the build
-      git diff-index --quiet HEAD --
+  - script: ./ci.sh tox-3.x docker-4.x
     displayName: 'Tox 3.x, Docker 4.x'

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+set -x
+
+tox_version=$1
+docker_version=$2
+
+pip install --constraint $tox_version --constraint $docker_version .
+pip show tox tox-docker docker
+tox
+echo "testing health check failure handling, an ERROR is expected:"
+tox -e healthcheck-failing 2>&1 | egrep "tox_docker.HealthCheckFailed: 'alpine:3.12' failed health check"

--- a/test_integration.py
+++ b/test_integration.py
@@ -2,7 +2,11 @@ from contextlib import contextmanager
 import os
 import sys
 import unittest
-from unittest.mock import patch
+
+try:
+    from unittest.mock import patch
+except:
+    from mock import patch
 
 try:
     from urllib.request import urlopen

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,9 @@ docker =
     ksdn117/tcp-udp-test
 dockerenv =
     ENV_VAR=env-var-value
-deps = pytest
+deps =
+    pytest
+    mock; python_version == '2.7'
 commands = py.test [] test_integration.py
 
 [testenv:registry]
@@ -46,6 +48,19 @@ healthcheck_interval = 1
 healthcheck_timeout = 1
 healthcheck_retries = 30
 healthcheck_start_period = 0.5
+
+# do NOT add this env to the envlist; it is supposed to fail,
+# and the CI scripts run it directly with this expectation
+[testenv:healthcheck-failing]
+docker = alpine:3.12
+commands = python -c ""
+
+[docker:alpine:3.12]
+healthcheck_cmd = /bin/false
+healthcheck_interval = 1
+healthcheck_timeout = 1
+healthcheck_retries = 3
+healthcheck_start_period = 0
 
 [testenv:ports]
 docker = mysql:5.7

--- a/tox_docker.py
+++ b/tox_docker.py
@@ -220,7 +220,11 @@ def tox_runtest_pre(venv):
                         time.sleep(0.1)
                     elif health == "unhealthy":
                         # the health check failed after its own timeout
-                        raise HealthCheckFailed("{!r} failed health check".format(image))
+                        stop_containers(venv)
+                        # TODO in 2.0: remove str() below for py27 compatibility
+                        msg = "{!r} failed health check".format(str(image))
+                        venv.status = msg
+                        raise HealthCheckFailed(msg)
 
         name, _, tag = image.partition(":")
         gateway_ip = _get_gateway_ip(container)
@@ -282,6 +286,10 @@ def tox_runtest_pre(venv):
 
 @hookimpl
 def tox_runtest_post(venv):
+    stop_containers(venv)
+
+
+def stop_containers(venv):
     envconfig = venv.envconfig
     if not envconfig.docker:
         return


### PR DESCRIPTION
fixes #51

tox inspects the `venv.status` attribute, if it's non-empty (and doesn't match certain values) then it prints the message and fails the tox run. see https://github.com/tox-dev/tox/blob/db8cfba41ad34493e7d5de4ac1a55d3c264c0a13/src/tox/session/__init__.py#L267-L270