### PR TITLE
move all docker configuration to the [docker:...] sections

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -9,4 +9,4 @@ pip install --constraint $tox_version --constraint $docker_version .
 pip show tox tox-docker docker
 tox
 echo "testing health check failure handling, an ERROR is expected:"
-tox -e healthcheck-failing 2>&1 | egrep "tox_docker.HealthCheckFailed: 'alpine:3.12' failed health check"
+tox -e healthcheck-failing 2>&1 | egrep "tox_docker.HealthCheckFailed: .* failed health check"

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ force_grid_wrap = false
 from_first = true
 include_trailing_comma = true
 # known_third_party is autogenereated. Do not edit.
-known_third_party =docker,py,setuptools,tox,vcversioner
+known_third_party =docker,py,pytest,setuptools,tox,vcversioner
 lines_after_types = 1
 multi_line_output = 3
 not_skip = __init__.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,5 @@
 [tox]
-envlist = integration,registry,healthcheck-builtin,healthcheck-custom,ports,links
-
-[testenv]
-# commands_pre/_post only work in tox 3.4+, but at least in some
-# CI configurations they'll tell us if we've leaked resources
-commands_pre = python tox_docker/tests/capture_containers_and_volumes.py
-commands_post = python tox_docker/tests/assert_containers_and_volumes_unchanged.py
+envlist = integration
 
 [testenv:docs]
 deps =
@@ -32,72 +26,80 @@ commands =
     flake8 tox_docker
 
 [testenv:integration]
+# commands_pre/_post only work in tox 3.4+, but at least in some
+# CI configurations they'll tell us if we've leaked resources
+commands_pre = python tox_docker/tests/capture_containers_and_volumes.py
+commands_post = python tox_docker/tests/assert_containers_and_volumes_unchanged.py
 docker =
-    nginx:1.13-alpine
-    ksdn117/tcp-udp-test
-dockerenv =
-    ENV_VAR=env-var-value
+    tcp-udp-test
+    nginx-from-registry-url
+    healthcheck-builtin
+    healthcheck-custom
+    links-httpd
+    links-registry
+    links-nginx
+    custom-port-mapping
 deps =
     pytest
-commands = py.test [] tox_docker/tests/test_integration.py
+    pudb
+commands = py.test [] {toxinidir}/tox_docker
 
-[testenv:registry]
-docker = docker.io/library/nginx:1.13-alpine
-deps = pytest
-commands = py.test [] tox_docker/tests/test_registry.py
+[docker:tcp-udp-test]
+# used by test cases to ensure we map both TCP and UDP ports
+image = ksdn117/tcp-udp-test
 
-[testenv:healthcheck-builtin]
-docker = healthcheck/redis:alpine
-deps = pytest
-commands = py.test [] tox_docker/tests/test_healthcheck.py
+[docker:nginx-from-registry-url]
+# used by test cases to ensure we can specify image as a URL
+image = docker.io/library/nginx:1.19-alpine
 
-[testenv:healthcheck-custom]
-docker = redis:5-alpine
-deps = pytest
-commands = py.test [] tox_docker/tests/test_healthcheck.py
+[docker:healthcheck-builtin]
+image = healthcheck/redis:alpine
+# the default health check start period seems to be 30s, make tests faster
+healthcheck_interval = 1
+healthcheck_timeout = 1
+healthcheck_start_period = 1
 
-[docker:redis:5-alpine]
+[docker:healthcheck-custom]
+image = redis:5-alpine
 healthcheck_cmd = redis-cli ping | grep -q PONG
 healthcheck_interval = 1
 healthcheck_timeout = 1
-healthcheck_retries = 30
-healthcheck_start_period = 0.5
+healthcheck_start_period = 1
+
+[docker:custom-port-mapping]
+# https://github.com/docker-library/mysql/blob/master/5.7/Dockerfile exposes 33060,
+# our test will verify that our custom mapping is respected and host's 3306 is bound
+image = mysql:5.7
+environment =
+    MYSQL_ALLOW_EMPTY_PASSWORD=true
+ports = 3306:3306/tcp
+
+[docker:links-httpd]
+image = httpd:2.4-alpine
+
+[docker:links-registry]
+image = registry.hub.docker.com/library/registry:2.7
+links = links-httpd:apache
+
+[docker:links-nginx]
+image = nginx:1.19-alpine
+links =
+    links-registry:hub
+    links-httpd
 
 # do NOT add this env to the envlist; it is supposed to fail,
 # and the CI scripts run it directly with this expectation
 [testenv:healthcheck-failing]
-docker = alpine:3.12
+skip_install = true
 commands = python -c ""
+docker = healthcheck-failing
 
-[docker:alpine:3.12]
+[docker:healthcheck-failing]
+# we don't need redis in particular, just anything with /bin/false
+# (we use this since the CI test runs will have already pulled it)
+image = redis:5-alpine
 healthcheck_cmd = /bin/false
 healthcheck_interval = 1
 healthcheck_timeout = 1
 healthcheck_retries = 3
 healthcheck_start_period = 0
-
-[testenv:ports]
-docker = mysql:5.7
-dockerenv =
-    MYSQL_ALLOW_EMPTY_PASSWORD=true
-deps = pytest
-commands = py.test [] tox_docker/tests/test_ports.py
-
-[docker:mysql:5.7]
-ports = 3306:3306/tcp
-
-[testenv:links]
-docker =
-    httpd:2.4-alpine
-    registry.hub.docker.com/library/registry:2.7
-    nginx:1.19-alpine
-deps = pytest
-commands = py.test [] tox_docker/tests/test_links.py
-
-[docker:registry.hub.docker.com/library/registry:2.7]
-links = httpd:apache
-
-[docker:nginx:1.19-alpine]
-links =
-    registry.hub.docker.com/library/registry:hub
-    httpd

--- a/tox_docker/tests/test_healthcheck.py
+++ b/tox_docker/tests/test_healthcheck.py
@@ -1,19 +1,9 @@
-import unittest
+import pytest
 
-import docker
+from tox_docker.tests.util import find_container
 
 
-class ToxDockerHealthCheckTest(unittest.TestCase):
-    def test_it_waits_for_health_check_to_succeed(self):
-        # the redis instance takes a few seconds to ack its healthcheck;
-        # this is sloppy and might have false positives, but it should
-        # have no false negatives (if it fails, tox-docker _is_ broken)
-        client = docker.from_env(version="auto")
-        redis_container = None
-        for container in client.containers.list():
-            if "redis" in container.attrs["Config"]["Image"]:
-                redis_container = container
-                break
-
-        self.assertIsNotNone(redis_container, "could not find redis container")
-        self.assertEqual("healthy", redis_container.attrs["State"]["Health"]["Status"])
+@pytest.mark.parametrize("instance_name", ["healthcheck-builtin", "healthcheck-custom"])
+def test_the_image_is_healthy_builtin(instance_name):
+    container = find_container("healthcheck-builtin")
+    assert container.attrs["State"]["Health"]["Status"] == "healthy"

--- a/tox_docker/tests/test_integration.py
+++ b/tox_docker/tests/test_integration.py
@@ -9,27 +9,21 @@ from tox_docker import _get_gateway_ip
 
 
 class ToxDockerIntegrationTest(unittest.TestCase):
-    # TODO: These tests depend too heavily on what's in tox.ini,
-    # but they're better than nothing
-
-    def test_it_sets_specific_env_vars(self):
-        self.assertEqual("env-var-value", os.environ["ENV_VAR"])
-
     def test_it_sets_automatic_env_vars(self):
-        # the nginx image we use exposes port 80
-        self.assertIn("NGINX_HOST", os.environ)
-        self.assertIn("NGINX_80_TCP_PORT", os.environ)
-
-        # the test image we use exposes TCP port 1234 and UDP port 5678
-        self.assertIn("KSDN117_TCP_UDP_TEST_1234_TCP_PORT", os.environ)
-        self.assertIn("KSDN117_TCP_UDP_TEST_5678_UDP_PORT", os.environ)
+        # ksdn117/tcp-udp-test exposes TCP port 1234 and UDP port 5678
+        self.assertIn("TCP_UDP_TEST_1234_TCP_PORT", os.environ)
+        self.assertIn("TCP_UDP_TEST_5678_UDP_PORT", os.environ)
 
     def test_it_exposes_the_port(self):
-        # the nginx image we use exposes port 80
-        url = f"http://{os.environ['NGINX_HOST']}:{os.environ['NGINX_80_TCP_PORT']}/"
-        response = urlopen(url)
+        self.assertIn("NGINX_FROM_REGISTRY_URL_HOST", os.environ)
+        self.assertIn("NGINX_FROM_REGISTRY_URL_80_TCP_PORT", os.environ)
+
+        host = os.environ["NGINX_FROM_REGISTRY_URL_HOST"]
+        port = os.environ["NGINX_FROM_REGISTRY_URL_80_TCP_PORT"]
+
+        response = urlopen(f"http://{host}:{port}/")
         self.assertEqual(200, response.getcode())
-        self.assertIn("Thank you for using nginx.", str(response.read()))
+        self.assertIn(b"Thank you for using nginx.", response.read())
 
 
 @contextmanager

--- a/tox_docker/tests/test_registry.py
+++ b/tox_docker/tests/test_registry.py
@@ -1,19 +1,8 @@
-import os
-import unittest
-
 from tox_docker import escape_env_var
 
 
-class ToxDockerRegistryTest(unittest.TestCase):
-    def test_it_sets_automatic_env_vars(self):
-        # we assume that if these envvars are set, the image (configured to
-        # be pulled from a registry URI rather than by name) was successfully
-        # pulled & started
-        self.assertIn("DOCKER_IO_LIBRARY_NGINX_HOST", os.environ)
-        self.assertIn("DOCKER_IO_LIBRARY_NGINX_80_TCP_PORT", os.environ)
-
-    def test_escape_env_var(self):
-        self.assertEqual(
-            escape_env_var("my.private.registry/cat/image"),
-            "MY_PRIVATE_REGISTRY_CAT_IMAGE",
-        )
+def test_escape_env_var():
+    assert (
+        escape_env_var("my.private.registry/cat/image")
+        == "MY_PRIVATE_REGISTRY_CAT_IMAGE"
+    )

--- a/tox_docker/tests/util.py
+++ b/tox_docker/tests/util.py
@@ -1,0 +1,13 @@
+import docker
+import pytest
+
+
+def find_container(instance_name):
+    # TODO: refactor this as a pytest fixture
+    client = docker.from_env(version="auto")
+    for container in client.containers.list():
+        labels = container.attrs["Config"].get("Labels", {})
+        if labels.get("tox_docker_container_name") == instance_name:
+            return container
+
+    pytest.fail(f"No running container with instance name {instance_name!r}")


### PR DESCRIPTION
Much as described in #65.

Additionally:
* The container name (the `whatever` in `[docker:whatever]`) is now set as the actual name of the container in Docker
* Any or all of the healthcheck configurations can be specified without specifying all of them; for cases where the image has a built-in healthcheck, the interval, start period, timeout, etc, apply to the in-built healthcheck command, and override the docker defaults.
* Most of the testenvs are now collapsed into a single `[testenv:integration]`, which runs all the containers. This should be faster to CI, as we save the repeated reinstallation overhead.