### PR TITLE
support bind-mounted volumes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,15 @@ The ``[docker:container-name]`` section may contain the following directives:
     in the ``docker`` directive of your testenv -- tox-docker does not attempt
     to resolve a valid start order.
 
+``volumes``
+    A multi-line list of `volumes
+    <https://docs.docker.com/storage/volumes/>`__ to make available to the
+    container, as ``<type>:<options>:<outside_path_or_name>:<inside_path>``.
+    The ``type`` must be ``bind``, and the only supported options are ``rw``
+    (read-write) or ``ro`` (read-only). The ``outside_path_or_name`` must
+    be a path that exists on the host system. Both the ``outside_path``
+    and ``inside_path`` must be absolute paths.
+
 ``healthcheck_cmd``, ``healthcheck_interval``, ``healthcheck_retries``, ``healthcheck_start_period``, ``healthcheck_timeout``
     These set or customize parameters of the container `health check
     <https://docs.docker.com/engine/reference/builder/#healthcheck>`__. The
@@ -135,6 +144,12 @@ Example
     healthcheck_retries = 30
     healthcheck_interval = 1
     healthcheck_start_period = 1
+    # Configure a bind-mounted volume on the host to store Postgres' data
+    # NOTE: this is included for demonstration purposes of tox-docker's
+    # volume capability; you probably _don't_ want to do this for real
+    # testing use cases, as this could persist data between test runs
+    volumes =
+        bind:rw:/my/own/datadir:/var/lib/postgresql/data
 
     [docker:appserv]
     # You can use any value that `docker run` would accept as the image

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,11 @@ docker =
 deps =
     pytest
     pudb
-commands = py.test [] {toxinidir}/tox_docker
+setenv =
+    VOLUME_DIR={toxworkdir}
+commands =
+    py.test [] {toxinidir}/tox_docker
+    python -c 'import os; os.remove(os.environ["VOLUME_DIR"] + "/healthy")'
 
 [docker:networking-one]
 image = ksdn117/tcp-udp-test
@@ -69,7 +73,8 @@ healthcheck_cmd = touch /healthcheck/web/healthy
 healthcheck_interval = 1
 healthcheck_timeout = 1
 healthcheck_start_period = 1
-
+volumes =
+    bind:rw:{toxworkdir}:/healthcheck/web
 
 # do NOT add this env to the envlist; it is supposed to fail,
 # and the CI scripts run it directly with this expectation

--- a/tox_docker/__init__.py
+++ b/tox_docker/__init__.py
@@ -4,11 +4,13 @@ import socket
 import sys
 import time
 
-from docker.errors import ImageNotFound
 from tox import hookimpl
 from tox.config import SectionReader
-import docker as docker_module
 import py
+
+from docker.errors import ImageNotFound
+from docker.types import Mount
+import docker as docker_module
 
 # nanoseconds in a second; named "SECOND" so that "1.5 * SECOND" makes sense
 SECOND = 1000000000
@@ -112,6 +114,12 @@ def tox_configure(config):  # noqa: C901
         if not section.startswith("docker:"):
             continue
         reader = SectionReader(section, iniparser)
+        reader.addsubstitutions(
+            distdir=config.distdir,
+            homedir=config.homedir,
+            toxinidir=config.toxinidir,
+            toxworkdir=config.toxworkdir,
+        )
         _, _, container_name = section.partition(":")
 
         container_configs[container_name]["image"] = reader.getstring("image")
@@ -151,6 +159,13 @@ def tox_configure(config):  # noqa: C901
                 if link_line.strip()
             )
 
+        if reader.getstring("volumes"):
+            container_configs[container_name]["mounts"] = [
+                _validate_volume_line(volume_line)
+                for volume_line in reader.getlist("volumes")
+                if volume_line.strip()
+            ]
+
     config._docker_container_configs = container_configs
 
 
@@ -174,6 +189,28 @@ def _validate_link_line(link_line, container_names):
     if other_container_name not in container_names:
         raise ValueError(f"Container {other_container_name!r} not defined")
     return other_container_name, alias or other_container_name
+
+
+def _validate_volume_line(volume_line):
+    parts = volume_line.split(":")
+    if len(parts) != 4:
+        raise ValueError(f"Volume {volume_line!r} is malformed")
+    if parts[0] != "bind":
+        raise ValueError(f"Volume {volume_line!r} type must be 'bind:'")
+    if parts[1] not in ("ro", "rw"):
+        raise ValueError(f"Volume {volume_line!r} options must be 'ro' or 'rw'")
+
+    volume_type, mode, outside, inside = parts
+    if not os.path.exists(outside):
+        raise ValueError(f"Volume source {outside!r} does not exist")
+    if not os.path.isabs(outside):
+        raise ValueError(f"Volume source {outside!r} must be an absolute path")
+    if not os.path.isabs(inside):
+        raise ValueError(f"Mount point {inside!r} must be an absolute path")
+
+    return Mount(
+        source=outside, target=inside, type=volume_type, read_only=bool(mode == "ro"),
+    )
 
 
 @hookimpl  # noqa: C901
@@ -257,6 +294,7 @@ def tox_runtest_pre(venv):  # noqa: C901
                 name=container_name,
                 ports=ports,
                 publish_all_ports=len(ports) == 0,
+                mounts=container_config.get("mounts", []),
             )
 
         envconfig._docker_containers[container_name] = container

--- a/tox_docker/tests/test_volumes.py
+++ b/tox_docker/tests/test_volumes.py
@@ -1,0 +1,9 @@
+import os
+
+
+def test_the_image_is_healthy():
+    # the healthcheck creates a file "healthy" in the volume from within
+    # the container; this test proves it's visible outside the container,
+    # and thus the bind mount worked as expected
+    volume = os.environ["VOLUME_DIR"]
+    assert "healthy" in os.listdir(volume)


### PR DESCRIPTION
fixes #45

This also makes the [globally available substitutions](https://tox.readthedocs.io/en/latest/config.html#globally-available-substitutions) availalbe in the `[docker]` sections (as was needed for a test case).