### PR TITLE
Randomize container names to avoid conflcits

### DIFF
--- a/tox_docker/__init__.py
+++ b/tox_docker/__init__.py
@@ -1,4 +1,5 @@
 import os
+import random
 import re
 import socket
 import sys
@@ -307,7 +308,7 @@ def tox_runtest_pre(venv):  # noqa: C901
                 healthcheck=healthcheck,
                 labels={"tox_docker_container_name": container_name},
                 links=links,
-                name=container_name,
+                name=f"{container_name}_{random.randint(100000, 999999)}",
                 ports=ports,
                 publish_all_ports=len(ports) == 0,
                 mounts=container_config.get("mounts", []),

--- a/tox_docker/tests/test_containers.py
+++ b/tox_docker/tests/test_containers.py
@@ -1,3 +1,5 @@
+import re
+
 from tox_docker.tests.util import find_container
 
 
@@ -7,3 +9,9 @@ def test_it_can_run_two_of_the_same_image():
 
     assert hc_builtin.id != hc_custom.id
     assert hc_builtin.attrs["Image"] == hc_custom.attrs["Image"]
+
+
+def test_container_name_has_random_suffix():
+    networking_container = find_container("networking-one")
+    # 5 digit random number
+    assert re.search("^networking-one_\d{5}", networking_container.name)

--- a/tox_docker/tests/test_healthcheck.py
+++ b/tox_docker/tests/test_healthcheck.py
@@ -10,5 +10,5 @@ def test_the_image_is_healthy(instance):
     port = os.environ[f"{instance}_8000_TCP_PORT"]
     url = f"http://{host}:{port}/healthy"
 
-    response = urlopen(url)
+    response = urlopen(url, timeout=5)
     assert response.getcode() == 200, f"GET {url} => {response.getcode()}"

--- a/tox_docker/tests/test_ports.py
+++ b/tox_docker/tests/test_ports.py
@@ -6,7 +6,7 @@ def test_exposed_ports_are_accessible_to_test_runs():
     host = os.environ["HEALTHCHECK_BUILTIN_HOST"]
     port = os.environ["HEALTHCHECK_BUILTIN_8000_TCP_PORT"]
 
-    response = urlopen(f"http://{host}:{port}/")
+    response = urlopen(f"http://{host}:{port}/", timeout=5)
     assert response.getcode() == 200
     assert b"Directory listing for /" in response.read()
 


### PR DESCRIPTION
If two instances of tox are run in the same machine then spinning up
container with same name fails with 409 due to conflict, so, add a
random suffix to avoid conflict.