### PR TITLE
Allow the user to set a container as `privileged`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,13 @@ The ``[docker:container-name]`` section may contain the following directives:
     This value is passed directly to Docker, and may be of any of the forms
     that Docker accepts in eg ``docker run``.
 
+``privileged``
+    A boolean (``true || false``) to set `runtime privilege
+    <https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities>`__.
+    This value is coerced to a boolean based of the same rules as
+    Python's default `ConfigParser
+    <https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.getboolean>`__.
+
 ``environment``
     A multi-line list of ``KEY=value`` settings which is used to set
     environment variables for the container. The variables are only available

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ ports =
 [docker:networking-two]
 # along with networking-one, proves we can run multiple copies of the same image
 image = ksdn117/tcp-udp-test
+privileged = off
 ports = 2345:1234/tcp
 links = networking-one:linked_host
 
@@ -65,6 +66,7 @@ healthcheck_start_period = 1
 
 [docker:healthcheck-custom]
 image = docker.io/toxdocker/healthcheck:latest
+privileged = true
 healthcheck_cmd = touch /healthcheck/web/healthy
 healthcheck_interval = 1
 healthcheck_timeout = 1

--- a/tox_docker/config.py
+++ b/tox_docker/config.py
@@ -109,6 +109,7 @@ class ContainerConfig:
         name: str,
         image: Image,
         stop: bool,
+        privileged: bool = False,
         environment: Optional[Mapping[str, str]] = None,
         healthcheck_cmd: Optional[str] = None,
         healthcheck_interval: Optional[float] = None,
@@ -123,6 +124,7 @@ class ContainerConfig:
         self.runas_name = runas_name(name)
         self.image = image
         self.stop = stop
+        self.privileged = privileged
         self.environment: Mapping[str, str] = environment or {}
         self.ports: Collection[Port] = ports or {}
         self.links: Collection[Link] = links or {}

--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -108,6 +108,7 @@ def docker_run(
         ports=ports,
         publish_all_ports=len(ports) == 0,
         mounts=container_config.mounts,
+        privileged=container_config.privileged,
     )
     container.reload()  # TODO: why do we need this?
     return container

--- a/tox_docker/tests/test_privileged.py
+++ b/tox_docker/tests/test_privileged.py
@@ -1,0 +1,19 @@
+from tox_docker.tests.util import find_container
+
+
+def test_can_grant_privileged() -> None:
+    container = find_container("healthcheck-custom")
+
+    assert container.attrs["HostConfig"]["Privileged"] is True
+
+
+def test_can_deny_privileged() -> None:
+    container = find_container("networking-two")
+
+    assert container.attrs["HostConfig"]["Privileged"] is False
+
+
+def test_not_privileged_by_default() -> None:
+    container = find_container("healthcheck-builtin")
+
+    assert container.attrs["HostConfig"]["Privileged"] is False


### PR DESCRIPTION
I'm trying to set up some integration tests which need `k3s` to run. However, this container needs to run as `privileged`.