### PR TITLE
Add ability to pass custom `command` to container

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,10 @@ The ``[docker:container-name]`` section may contain the following directives:
     This value is passed directly to Docker, and may be of any of the forms
     that Docker accepts in eg ``docker run``.
 
+``command``
+    A string defining the command to run in the container. If this is not set
+    then the default ``CMD`` set by the image will run.
+
 ``environment``
     A multi-line list of ``KEY=value`` settings which is used to set
     environment variables for the container. The variables are only available

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ docker =
     networking-two
     healthcheck-builtin
     healthcheck-custom
+    custom-command
 deps =
     pytest
 setenv =
@@ -71,6 +72,10 @@ healthcheck_timeout = 1
 healthcheck_start_period = 1
 volumes =
     bind:rw:{toxworkdir}:/healthcheck/web
+
+[docker:custom-command]
+image = alpine:latest
+command = echo "hello world"
 
 # do NOT add this env to the envlist; it is supposed to fail,
 # and the CI scripts run it directly with this expectation

--- a/tox_docker/config.py
+++ b/tox_docker/config.py
@@ -109,6 +109,7 @@ class ContainerConfig:
         name: str,
         image: Image,
         stop: bool,
+        command: Optional[str] = None,
         environment: Optional[Mapping[str, str]] = None,
         healthcheck_cmd: Optional[str] = None,
         healthcheck_interval: Optional[float] = None,
@@ -123,6 +124,7 @@ class ContainerConfig:
         self.runas_name = runas_name(name)
         self.image = image
         self.stop = stop
+        self.command = command
         self.environment: Mapping[str, str] = environment or {}
         self.ports: Collection[Port] = ports or {}
         self.links: Collection[Link] = links or {}

--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -100,6 +100,7 @@ def docker_run(
     log(f"run {container_config.image!r} (from {container_config.name!r})")
     container = docker.containers.run(
         str(container_config.image),
+        command=container_config.command,
         name=container_config.runas_name,
         detach=True,
         environment=container_config.environment,

--- a/tox_docker/tests/test_containers.py
+++ b/tox_docker/tests/test_containers.py
@@ -15,3 +15,11 @@ def test_container_has_unique_runas_suffix() -> None:
     assert container.name != "healthcheck-builtin"
     # don't test the details of how we do this; the suffix could be some
     # randomly-chosen suffix, could be PID (it is), or something else
+
+
+def test_can_run_with_command():
+    container = find_container("custom-command")
+
+    assert container.attrs["Path"] == "echo"
+    assert container.attrs["Args"] == ["hello world"]
+    assert container.attrs["Config"]["Cmd"] == ["echo", "hello world"]

--- a/tox_docker/tests/test_containers.py
+++ b/tox_docker/tests/test_containers.py
@@ -17,7 +17,7 @@ def test_container_has_unique_runas_suffix() -> None:
     # randomly-chosen suffix, could be PID (it is), or something else
 
 
-def test_can_run_with_command():
+def test_can_run_with_command() -> None:
     container = find_container("custom-command")
 
     assert container.attrs["Path"] == "echo"

--- a/tox_docker/tests/util.py
+++ b/tox_docker/tests/util.py
@@ -15,7 +15,7 @@ def find_container(instance_name: str) -> Container:
     # get the right runas_name()
     running_name = runas_name(instance_name, pid=os.getppid())
     client = docker.from_env(version="auto")
-    for container in client.containers.list():
+    for container in client.containers.list(all=True):
         container.attrs["Config"].get("Labels", {})
         if container.name == running_name:
             return container

--- a/tox_docker/tox3/config.py
+++ b/tox_docker/tox3/config.py
@@ -136,6 +136,7 @@ def parse_container_config(
     return ContainerConfig(
         name=container_name,
         image=Image(reader.getstring("image")),
+        command=reader.getstring("command"),
         stop=container_name not in config.option.docker_dont_stop,
         environment=environment,
         healthcheck_cmd=hc_cmd,

--- a/tox_docker/tox4/config.py
+++ b/tox_docker/tox4/config.py
@@ -98,6 +98,7 @@ def parse_container_config(docker_config: DockerConfigSet) -> ContainerConfig:
     return ContainerConfig(
         name=docker_config.name,
         image=docker_config["image"],
+        command=docker_config["command"],
         stop=docker_config.name not in docker_config._conf.options.docker_dont_stop,
         environment=docker_config["environment"],
         healthcheck_cmd=docker_config["healthcheck_cmd"],

--- a/tox_docker/tox4/config.py
+++ b/tox_docker/tox4/config.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from tox.config.sets import ConfigSet
 
@@ -27,6 +27,12 @@ class DockerConfigSet(ConfigSet):
             default=Image(""),
             desc="docker image to run",
             post_process=image_required,
+        )
+        self.add_config(
+            keys=["command"],
+            of_type=Optional[str],
+            default=None,
+            desc="docker command to run in the container",
         )
         self.add_config(
             keys=["environment"],


### PR DESCRIPTION
Fixes issue https://github.com/tox-dev/tox-docker/issues/114

More up to date version of #115 