### PR TITLE
revamp port mapping to the container

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,37 +73,27 @@ The ``[docker:container-name]`` section may contain the following directives:
     environment variables for the container. The variables are only available
     to the container, not to other containers or the test environment.
 
-``ports``
+``expose``
     A multi-line list of port mapping specifications, as
-    ``HOST_PORT:CONTAINER_PORT/PROTO``, which causes the container's
-    ``EXPOSE`` d port to be available on ``HOST_PORT``. See below for
-    more on port mapping.
+    ``ENV_VAR=CONTAINER_PORT/PROTO``. Within the testenv, the environment
+    variable ``ENV_VAR`` will contain the port number to connect to the
+    docker container's ``EXPOSE`` d port. If ``expose`` is specified, only
+    the listed ports will have environment variables created for them.
 
-    If ``ports`` is not specified, all the container's ``EXPOSE`` d ports are
-    mapped (equivalent to ``docker run -P ...``)
-
-    For each mapped port, an environment variable of the form
+    If ``expose`` is not specified, all the container's ``EXPOSE`` d ports are
+    made available (equivalent to ``docker run -P ...``) using default
+    environment variable names of the form
     ``<container-name>_<port-number>_<protocol>_PORT`` (eg
-    ``NGINX_80_TCP_PORT`` or ``TELEGRAF_8092_UDP_PORT``) is set for the test
-    run.
+    ``NGINX_80_TCP_PORT`` or ``TELEGRAF_8092_UDP_PORT``). The container name
+    part is converted to upper case, and all non-alphanumeric characters are
+    replaced with an underscore (``_``).
 
-    For each container, an environment variable of the form
-    ``<container_name>_HOST`` is set for the test run, indicating the host
-    name or IP address to use to communicate with the container.
-
-    If you set the ``HOST_PORT`` to zero, a random available port will be
-    assigned on the tox host. This is useful in case the container does not
-    ``EXPOSE`` the port you need, or if you want to map only some of the
-    ``EXPOSE``\d ports.
-
-    In both environment variables, the container name part is converted to
-    upper case, and all non-alphanumeric characters are replaced with an
-    underscore (``_``).
-
-    Tox-docker does not attempt to ensure that you have proper permission to
-    bind the ``HOST_PORT``, that it is not already bound and listening, etc;
-    if you explicitly list ports, it is your responsibility to ensure that
-    it can be successfully mapped.
+``host_var``
+    A single string, with the name of an environment variable that will
+    contain the name or IP address to use to communicate with the container.
+    Defaults to ``<container_name>>_HOST`` if not set. The container name
+    part is converted to upper case, and all non-alphanumeric characters
+    are replaced with an underscore (``_``).
 
 ``links``
     A multi-line list of `container links
@@ -206,11 +196,9 @@ Example
     # Within the appserv container, host "db" is linked to the postgres container
     links =
         db:db
-    # Use ports to expose specific ports; if you don't specify ports, then all
-    # the EXPOSEd ports defined by the image are mapped to an available
-    # ephemeral port.
-    ports =
-        8080:8080/tcp
+    # Expose ports to the testenv
+    expose =
+        APP_HTTP_PORT=8080/tcp
 
 
 Environment Variables
@@ -227,6 +215,18 @@ Tox-docker requires tox to be run in Python 3.8 or newer, and requires tox
 version 4 or newer. Older versions of tox-docker may work with older
 versions of Python or tox, but these configurations are no longer supported.
 
+Upgrading
+---------
+
+Some configuration options were removed:
+
+New in 5.0:
+
+``ports``
+    This directive was removed in tox-docker version 5.0. Use ``expose``
+    instead. The ability to map a container port to a specific host port was
+    completely removed.
+
 
 ==========
 Change Log
@@ -235,6 +235,7 @@ Change Log
 * 5.0.0
     * Remove support for tox 3
     * Removed support for Python 3.7 and earlier
+    * Remove ``ports``; add ``expose`` and ``host_var``
 * 4.1.1
     * Fix typo in README (thanks @akx)
 * 4.1.0

--- a/README.rst
+++ b/README.rst
@@ -80,20 +80,20 @@ The ``[docker:container-name]`` section may contain the following directives:
     docker container's ``EXPOSE`` d port. If ``expose`` is specified, only
     the listed ports will have environment variables created for them.
 
-    If ``expose`` is not specified, all the container's ``EXPOSE`` d ports are
-    made available (equivalent to ``docker run -P ...``) using default
+    If ``expose`` is not specified, all the container's ``EXPOSE`` d ports
+    are made available (equivalent to ``docker run -P ...``) using default
     environment variable names of the form
-    ``<container-name>_<port-number>_<protocol>_PORT`` (eg
-    ``NGINX_80_TCP_PORT`` or ``TELEGRAF_8092_UDP_PORT``). The container name
-    part is converted to upper case, and all non-alphanumeric characters are
-    replaced with an underscore (``_``).
+    ``<container-name>_<port-number>_<protocol>_PORT`` (eg ``NGINX_80_TCP_PORT``
+    or ``TELEGRAF_8092_UDP_PORT``), with the container name and protocol
+    converted to upper case, and non-alphanumeric characters replaced with an
+    underscore (``_``).
 
 ``host_var``
-    A single string, with the name of an environment variable that will
-    contain the name or IP address to use to communicate with the container.
-    Defaults to ``<container_name>>_HOST`` if not set. The container name
-    part is converted to upper case, and all non-alphanumeric characters
-    are replaced with an underscore (``_``).
+    The name of an environment variable that will contain the hostname or IP
+    address to use to communicate with the container. Defaults to
+    ``<container_name>_HOST`` if not set, with the container name converted to
+    upper case, and non-alphanumeric characters replaced with an underscore
+    (``_``).
 
 ``links``
     A multi-line list of `container links

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ deps =
     pytest
 setenv =
     VOLUME_DIR={toxworkdir}
+package = wheel
+wheel_build_env = .pkg
 commands =
     py.test [] {toxinidir}/tox_docker
     python -c 'import os; os.remove(os.environ["VOLUME_DIR"] + "/healthy")'
@@ -40,15 +42,17 @@ commands =
 
 [docker:networking-one]
 image = ksdn117/tcp-udp-test
-ports =
-    0:1234/tcp
-    0:5678/udp
+expose =
+    ONE_1234_TCP_PORT=1234/tcp
+    ONE_5678_UDP_PORT=5678/udp
 
 [docker:networking-two]
 # along with networking-one, proves we can run multiple copies of the same image
 image = ksdn117/tcp-udp-test
-ports = 2345:1234/tcp
+expose =
+    TWO_1234_TCP_PORT=1234/tcp
 links = networking-one:linked_host
+host_var = NET_TWO_CUSTOM_HOST
 
 [docker:healthcheck-builtin]
 dockerfile = {toxinidir}/docker-images/healthcheck/Dockerfile

--- a/tox_docker/tests/test_env_vars.py
+++ b/tox_docker/tests/test_env_vars.py
@@ -1,17 +1,5 @@
-import os
-
-from tox_docker.plugin import escape_env_var
-
-
-def test_it_sets_automatic_env_vars() -> None:
-    # ksdn117/tcp-udp-test exposes TCP port 1234 and UDP port 5678
-    assert "NETWORKING_ONE_HOST" in os.environ
-    assert "NETWORKING_ONE_1234_TCP_PORT" in os.environ
-    assert "NETWORKING_ONE_5678_UDP_PORT" in os.environ
-
-    # the old names of these variables were dropped in 2.0
-    assert "NETWORKING_ONE_1234_TCP" not in os.environ
-    assert "NETWORKING_ONE_5678_UDP" not in os.environ
+from tox_docker.config import ContainerConfig, ExposedPort, Image
+from tox_docker.plugin import escape_env_var, get_port_env_var
 
 
 def test_escape_env_var() -> None:
@@ -19,3 +7,21 @@ def test_escape_env_var() -> None:
         escape_env_var("my.private.registry/cat/image")
         == "MY_PRIVATE_REGISTRY_CAT_IMAGE"
     )
+
+
+def test_get_port_env_var() -> None:
+    config = ContainerConfig(
+        name="foobar",
+        image=Image("foobar"),
+        dockerfile=None,
+        dockerfile_target="",
+        stop=True,
+        expose=[
+            ExposedPort("CUSTOM_ENV_VAR=1234/tcp"),
+        ],
+    )
+
+    assert "CUSTOM_ENV_VAR" == get_port_env_var(config, "1234/tcp")
+
+    # fall back to the default name if the port isn't specifically mapped
+    assert "FOOBAR_5678_TCP_PORT" == get_port_env_var(config, "5678/tcp")

--- a/tox_docker/tests/test_ports.py
+++ b/tox_docker/tests/test_ports.py
@@ -2,6 +2,31 @@ from urllib.request import urlopen
 import os
 
 
+def test_default_host_name_var() -> None:
+    # [docker:healthcheck-builtin] doesn't specify host_var
+    assert "HEALTHCHECK_BUILTIN_HOST" in os.environ
+
+
+def test_custom_host_name_var() -> None:
+    # [docker:healthcheck-custom] _does_ specify host_var=...
+    assert "NET_TWO_CUSTOM_HOST" in os.environ
+
+
+def test_EXPOSEd_ports_are_available_when_expose_is_not_set() -> None:
+    # [docker:healthcheck-builtin] does not have expose=
+    assert "HEALTHCHECK_BUILTIN_8000_TCP_PORT" in os.environ
+
+
+def test_EXPOSEd_ports_are_not_available_if_not_listed_in_expose() -> None:
+    # [docker:networking-two] doesn't map 5678/udp, but it is EXPOSEd
+    assert "NETWORKING_TWO_5678_UDP_PORT" not in os.environ
+
+
+def test_manually_mapped_ports_dont_get_default_port_envvar() -> None:
+    # [docker:networking-two] explicitly maps 1234/tcp
+    assert "NETWORKING_TWO_1234_TCP_PORT" not in os.environ
+
+
 def test_exposed_ports_are_accessible_to_test_runs() -> None:
     host = os.environ["HEALTHCHECK_BUILTIN_HOST"]
     port = os.environ["HEALTHCHECK_BUILTIN_8000_TCP_PORT"]
@@ -9,15 +34,3 @@ def test_exposed_ports_are_accessible_to_test_runs() -> None:
     response = urlopen(f"http://{host}:{port}/")
     assert response.getcode() == 200
     assert b"Directory listing for /" in response.read()
-
-
-def test_it_exposes_only_specified_port() -> None:
-    # this container remaps 1234/tcp to 2345, and hides 5678/udp
-    assert os.environ["NETWORKING_TWO_1234_TCP_PORT"] == "2345"
-    assert "NETWORKING_TWO_5678_UDP_PORT" not in os.environ
-
-
-def test_docker_picks_a_port_when_you_map_to_zero() -> None:
-    # tox.ini has `ports = 0:1234/tcp 0:5678/udp`
-    assert os.environ["NETWORKING_ONE_1234_TCP_PORT"] != "0"
-    assert os.environ["NETWORKING_ONE_5678_UDP_PORT"] != "0"


### PR DESCRIPTION
remove the `ports` directive, replace it with `expose` which gives greater user control; also add the `host_var` directive