### PR TITLE
Remove the seed-isort-config pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,6 @@ repos:
       - id: autoflake
         args: [--in-place, --remove-all-unused-imports, --remove-unused-variable, --exclude, 'tox_docker/__init__.py']
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,5 @@ atomic = true
 force_grid_wrap = false
 from_first = true
 include_trailing_comma = true
-# known_third_party is autogenereated. Do not edit.
-known_third_party =docker,pytest,setuptools,tox,vcversioner
 multi_line_output = 3
-not_skip = __init__.py
 order_by_type = false


### PR DESCRIPTION
The seed-isort-config hook is no longer supported/maintained, and its repo states it is no longer needed in isort v5.

Also, update the isort configuration to match [v5 migration recommendations](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html#not_skip).

Running `pre-commit run -a` showed no Python files are changed after making these changes.