### PR TITLE
skip docker 4, docker 5 on py312

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,10 @@ jobs:
 
   - script: ./ci.sh docker-5.x
     displayName: 'Docker 5.x'
+    # docker 5 uses distutils, removed in py312
+    condition: in(variables['python.version'], '3.11', '3.10', '3.9', '3.8')
 
   - script: ./ci.sh docker-4.x
     displayName: 'Docker 4.x'
+    # docker 4 uses distutils, removed in py312
+    condition: in(variables['python.version'], '3.11', '3.10', '3.9', '3.8')


### PR DESCRIPTION
docker 5.x and lower use distutils, which was removed in python 3.12. it's unclear why initial CI runs after I added the py312 run to the matrix worked, but here we are.