### PR TITLE
Fix Docker gateway IP detection for newer Docker versions

### DIFF
--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -50,7 +50,20 @@ def get_gateway_ip(container: Container) -> str:
         # made available on localhost (but 0.0.0.0 works just as well)
         ip = "0.0.0.0"
     else:
-        ip = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
+        # Try the legacy format first
+        legacy_gateway = container.attrs["NetworkSettings"].get("Gateway")
+        if legacy_gateway:
+            ip = legacy_gateway
+        else:
+            # For newer Docker versions, check Networks section
+            networks = container.attrs["NetworkSettings"].get("Networks", {})
+            # Try to find gateway in any network (typically 'bridge')
+            gateway_ip = None
+            for network_name, network_info in networks.items():
+                gateway_ip = network_info.get("Gateway")
+                if gateway_ip:
+                    break
+            ip = gateway_ip or "0.0.0.0"
     return ip
 
 


### PR DESCRIPTION
Improve gateway IP detection in get_gateway_ip() to handle both legacy and newer Docker API formats:

- Try legacy NetworkSettings.Gateway first for backwards compatibility
- Fall back to Networks section for newer Docker versions
- Iterate through all networks to find any available gateway
- Maintain "0.0.0.0" fallback for cases where no gateway is found

This resolves issues where newer Docker versions store network information in a different structure than the legacy format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
