### PR TITLE
Fix for NetworkSettings api change (docker engine >=29.0.0)

### DIFF
--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -49,7 +49,17 @@ def get_gateway_ip(container: Container) -> str:
         # there is no bridge network available in Docker for Mac, and exposed ports are
         # made available on localhost (but 0.0.0.0 works just as well)
         return "0.0.0.0"
-    return container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
+    network_settings = container.attrs["NetworkSettings"]
+    for network in network_settings.get("Networks", {}).values():
+        # preferred interface as of v1.21 API (docker 1.9.0, 2015-11-03)
+        # note behavior may not be correct if there are multiple networks.
+        # a more robust approach may be to prefer specific networks, i.e. "bridge"
+        if ip := network.get("Gateway"):
+            return ip
+    if ip := network_settings.get("Gateway"):
+        # deprecated interface, removed in v1.52 API (docker 29.0.0, 2025-11-10)
+        return ip
+    return "0.0.0.0"
 
 
 def escape_env_var(varname: str) -> str:

--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -43,15 +43,13 @@ class HealthCheckFailed(Exception):
 def get_gateway_ip(container: Container) -> str:
     gateway = os.getenv("TOX_DOCKER_GATEWAY")
     if gateway:
-        ip = socket.gethostbyname(gateway)
-    elif sys.platform == "darwin":
+        return socket.gethostbyname(gateway)
+    if sys.platform == "darwin":
         # https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds:
         # there is no bridge network available in Docker for Mac, and exposed ports are
         # made available on localhost (but 0.0.0.0 works just as well)
-        ip = "0.0.0.0"
-    else:
-        ip = container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
-    return ip
+        return "0.0.0.0"
+    return container.attrs["NetworkSettings"]["Gateway"] or "0.0.0.0"
 
 
 def escape_env_var(varname: str) -> str:


### PR DESCRIPTION
`get_gateway_ip` relies on `NetworkSettings.Gateway`, which has been deprecated for over ten years.  This field was removed in docker 29.0.0, released on 2025-11-10.  This fix favors the new API data schema so as to work with the latest versions of docker engine.  Quite possibly the old interface code could be removed altogether.

An open question is whether reliable support is required for a scenario in which the container has multiple networks, in which case preference should presumably be given to specific networks and not necessarily the first network listed.