### PR TITLE
Support active Docker contexts

### DIFF
--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -40,6 +40,21 @@ class HealthCheckFailed(Exception):
     pass
 
 
+def docker_client():
+    # docker.from_env() ignores the current context configuration.
+    # https://github.com/docker/docker-py/issues/3146
+
+    ctx = docker_module.ContextAPI.get_current_context()
+
+    base_url = os.environ.get("DOCKER_HOST", ctx.Host)
+
+    docker = docker_module.DockerClient(
+        base_url=base_url,
+        version="auto",
+    )
+    return docker
+
+
 def get_gateway_ip(container: Container) -> str:
     gateway = os.getenv("TOX_DOCKER_GATEWAY")
     if gateway:
@@ -124,7 +139,7 @@ def docker_build_or_pull(container_config: ContainerConfig) -> None:
 def docker_pull(container_config: ContainerConfig) -> None:
     assert container_config.image
 
-    docker = docker_module.from_env(version="auto")
+    docker = docker_client()
 
     try:
         docker.images.get(str(container_config.image))
@@ -163,7 +178,7 @@ def docker_run(
     container_config: ContainerConfig,
     running_containers: RunningContainers,
 ) -> Container:
-    docker = docker_module.from_env(version="auto")
+    docker = docker_client()
 
     healthcheck: Dict[str, Union[List[str], int]] = {}
     if container_config.healthcheck_cmd:
@@ -215,8 +230,6 @@ def docker_run(
 def docker_health_check(
     container_config: ContainerConfig, container: Container
 ) -> None:
-    docker = docker_module.from_env(version="auto")
-
     if "Health" in container.attrs["State"]:
         log(f"health check {container_config.name!r}")
         while True:
@@ -241,7 +254,7 @@ def docker_stop(container_config: ContainerConfig, container: Container) -> None
 
 
 def docker_get(container_config: ContainerConfig) -> Optional[Container]:
-    docker = docker_module.from_env(version="auto")
+    docker = docker_client()
     try:
         return docker.containers.get(container_config.runas_name)
     except NotFound:

--- a/tox_docker/plugin.py
+++ b/tox_docker/plugin.py
@@ -23,6 +23,7 @@ from tox.session.state import State
 from tox.tox_env.api import ToxEnv
 from tox.tox_env.errors import Fail
 import docker as docker_module
+import docker.utils
 
 from tox_docker.config import (
     ContainerConfig,
@@ -46,11 +47,12 @@ def docker_client():
 
     ctx = docker_module.ContextAPI.get_current_context()
 
-    base_url = os.environ.get("DOCKER_HOST", ctx.Host)
+    params = docker_module.utils.kwargs_from_env(os.environ)
+    params.setdefault("base_url", ctx.Host)
 
     docker = docker_module.DockerClient(
-        base_url=base_url,
         version="auto",
+        **params,
     )
     return docker
 


### PR DESCRIPTION
This PR enables tox-docker to correctly identify and connect to the active Docker context.

Currently, tox-docker relies on docker-py defaults, which ignores the active context and fail to find the correct socket (https://github.com/docker/docker-py/issues/3146). This change serves as a temporary workaround until an official fix is merged upstream.

I've already opened a pull-request to the official repo but i'm not receiving a lot of responses (it has been opened for a couple of weeks, it shows ~20h ago in the ui because i've rebased the commits): [docker/docker-py#3385](https://github.com/docker/docker-py/pull/3385)

Changes:
- read the docker server address from the current docker context if DOCKER_HOST is not provided.

I appreciate any feedback you might have
Thank you in advance for your time


